### PR TITLE
feat(logger): add an optional writer on creation

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -4,7 +4,6 @@
     "deadcode",
     "varcheck",
     "unconvert",
-    "unused",
     "staticcheck"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Logs will always include:
 * timestamp
 * nanoseconds
 
-Logs will always be written to stdout. The package ships with a global logger so you can easily emit logs without having to instantiate a logger.
+Logs be written to stdout by default. The package ships with a global logger so you can easily emit logs without having to instantiate a logger. This default logger will always write to stdout.
 
 ```go
 logger.Info("Hello, world!", logger.Data{"fun": "things"})
@@ -54,6 +54,16 @@ l1.Err(err).Error("unknown error")
 err = errors.New("bar")
 l1.Err(err).Error("unknown error")
 // {"level":"error","host":"HOSTNAME","release":"RELEASE","id":"test","error":{"message":"bar","stack":"\nmain.main\n\t/go/src/github.com/lob/logger-go/main.go:26\nruntime.main\n\t/.goenv/versions/1.10.3/src/runtime/proc.go:198\nruntime.goexit\n\t/.goenv/versions/1.10.3/src/runtime/asm_amd64.s:2361"},"nanoseconds":1531945897647586415,"timestamp":"2018-07-18T13:31:37-07:00","message":"unknown error"}
+```
+
+If you want the logger to use a specific writer to pipe logs to anywhere other than stdout, please use the `NewWithWriter` method. Make sure the argument you are passing in implements the writer interface.
+```go
+type CustomWriter struct{}
+func (cw *CustomWriter) Write(b []byte) (int, error) {
+	// your custom write logic here
+}
+
+loggerWithWriter := logger.NewWithWriter(CustomWriter{})
 ```
 
 The logger supports five levels of logging.

--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 
@@ -34,10 +35,15 @@ func init() {
 
 // New prepares and creates a new Logger instance.
 func New() Logger {
+	return NewWithWriter(os.Stdout)
+}
+
+// NewWithWriter prepares and creates a new Logger instance with a specified writer.
+func NewWithWriter(w io.Writer) Logger {
 	host, _ := os.Hostname()
 	release := os.Getenv("RELEASE")
 
-	zl := zerolog.New(os.Stdout).With().Timestamp().Str("host", host)
+	zl := zerolog.New(w).With().Timestamp().Str("host", host)
 
 	if release != "" {
 		zl = zl.Str("release", release)

--- a/logger_test.go
+++ b/logger_test.go
@@ -15,16 +15,16 @@ import (
 
 type FakeWriter struct{}
 
-func (fl FakeWriter) Write(b []byte) (int, error) {
+func (fl *FakeWriter) Write(b []byte) (int, error) {
 	return 0, nil
 }
 
-func (fl FakeWriter) Close() error {
+func (fl *FakeWriter) Close() error {
 	return nil
 }
 
 func TestNewWithWriter(t *testing.T) {
-	logger := NewWithWriter(FakeWriter{})
+	logger := NewWithWriter(&FakeWriter{})
 
 	assert.NotEmpty(t, logger)
 	assert.NotEmpty(t, logger.zl)

--- a/logger_test.go
+++ b/logger_test.go
@@ -8,8 +8,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pkg/errors"
 )
+
+type FakeWriter struct{}
+
+func (fl FakeWriter) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (fl FakeWriter) Close() error {
+	return nil
+}
+
+func TestNewWithWriter(t *testing.T) {
+	logger := NewWithWriter(FakeWriter{})
+
+	assert.NotEmpty(t, logger)
+	assert.NotEmpty(t, logger.zl)
+}
 
 func testLogger(t *testing.T, infoLevel string, infoMsg string, global bool) {
 	var id string


### PR DESCRIPTION
### What
Adds a `NewWithWriter` function to create a logger with a specified writer that is not `os.Stdout`.

### Why
To enable agent logging, we have created a [producer](https://github.com/lob/buzz/blob/3288aa34679236b51199c79f84f71c27822d6328/pkg/producer/producer.go#L1) package that implements the `io.Writer` interface to ship things to the Kinesis stream we set up for agent logs.

Therefore we would like the ability to send the logs to this type instead of to `os.Stdout`.