### PR TITLE
removing ip_address from request logs

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -60,7 +60,6 @@ func MiddlewareWithConfig(opts MiddlewareConfig) func(next echo.HandlerFunc) ech
 				"method":     c.Request().Method,
 				"route":      c.Path(),
 				"path":       c.Request().URL.Path,
-				"ip_address": ipAddress,
 				"trace_id":   c.Request().Header.Get("x-amzn-trace-id"),
 				"referer":    c.Request().Referer(),
 				"user_agent": c.Request().UserAgent(),

--- a/echo_test.go
+++ b/echo_test.go
@@ -53,7 +53,7 @@ func TestMiddleware(t *testing.T) {
 		assert.Equal(tt, http.StatusInternalServerError, rr.Code)
 	})
 
-	t.Run("pulls the IP from X-Forwarded-For", func(tt *testing.T) {
+	t.Run("does not capture IP address", func(tt *testing.T) {
 		e := echo.New()
 		out := capturer.CaptureStdout(func() {
 			e.Use(Middleware())
@@ -77,7 +77,7 @@ func TestMiddleware(t *testing.T) {
 		err := json.Unmarshal([]byte(out), &data)
 		require.NoError(tt, err)
 
-		assert.Equal(tt, "2.2.2.2", data["ip_address"])
+		assert.Equal(tt, nil, data["ip_address"])
 	})
 
 	t.Run("ignores errors according to IsIgnorableError", func(tt *testing.T) {

--- a/echo_test.go
+++ b/echo_test.go
@@ -77,7 +77,7 @@ func TestMiddleware(t *testing.T) {
 		err := json.Unmarshal([]byte(out), &data)
 		require.NoError(tt, err)
 
-		assert.Equal(tt, nil, data["ip_address"])
+		assert.NotContains(tt, data, "ip_address")
 	})
 
 	t.Run("ignores errors according to IsIgnorableError", func(tt *testing.T) {


### PR DESCRIPTION
- we're unilaterally removing the ip_address field across all logs for incoming requests before switching to Datadog
- I'm not actually sure if this works

![image](https://user-images.githubusercontent.com/551402/120392096-de217a00-c2e4-11eb-8ec5-aba295077c1e.png)
