### PR TITLE
INFRA-290: Add service name as required field in log factories (and assign to relevant DD fields)

### DIFF
--- a/context.go
+++ b/context.go
@@ -15,5 +15,5 @@ func FromContext(ctx context.Context) Logger {
 	if log, ok := ctx.Value(key{}).(Logger); ok {
 		return log
 	}
-	return New()
+	return New("")
 }

--- a/context_test.go
+++ b/context_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestWithContext(t *testing.T) {
 	id := "1234"
-	log := New().ID(id)
+	log := New("").ID(id)
 
 	ctx := log.WithContext(context.Background())
 
@@ -22,7 +22,7 @@ func TestWithContext(t *testing.T) {
 
 func TestFromContext(t *testing.T) {
 	id := "4321"
-	log := New().ID(id)
+	log := New("").ID(id)
 
 	ctx := log.WithContext(context.Background())
 

--- a/echo.go
+++ b/echo.go
@@ -24,15 +24,15 @@ const echoKey = "logger"
 // Middleware attaches a Logger instance with a request ID onto the context. It
 // also logs every request along with metadata about the request. To customize
 // the middleware, use MiddlewareWithConfig.
-func Middleware() func(next echo.HandlerFunc) echo.HandlerFunc {
-	return MiddlewareWithConfig(defaultMiddlewareConfig)
+func Middleware(serviceName string) func(next echo.HandlerFunc) echo.HandlerFunc {
+	return MiddlewareWithConfig(serviceName, defaultMiddlewareConfig)
 }
 
 // MiddlewareWithConfig attaches a Logger instance with a request ID onto the
 // context. It also logs every request along with metadata about the request.
 // Pass in a MiddlewareConfig to customize the behavior of the middleware.
-func MiddlewareWithConfig(opts MiddlewareConfig) func(next echo.HandlerFunc) echo.HandlerFunc {
-	l := New()
+func MiddlewareWithConfig(serviceName string, opts MiddlewareConfig) func(next echo.HandlerFunc) echo.HandlerFunc {
+	l := New(serviceName)
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -83,5 +83,5 @@ func FromEchoContext(c echo.Context) Logger {
 		return log
 	}
 
-	return New()
+	return New("")
 }

--- a/echo_test.go
+++ b/echo_test.go
@@ -16,7 +16,7 @@ import (
 func TestMiddleware(t *testing.T) {
 	t.Run("sets a request ID", func(tt *testing.T) {
 		e := echo.New()
-		e.Use(Middleware())
+		e.Use(Middleware(""))
 
 		e.GET("/", func(c echo.Context) error {
 			log, ok := c.Get("logger").(Logger)
@@ -37,7 +37,7 @@ func TestMiddleware(t *testing.T) {
 
 	t.Run("logs status code", func(tt *testing.T) {
 		e := echo.New()
-		e.Use(Middleware())
+		e.Use(Middleware(""))
 
 		e.GET("/", func(c echo.Context) error {
 			return errors.New("test")
@@ -56,7 +56,7 @@ func TestMiddleware(t *testing.T) {
 	t.Run("pulls the IP from X-Forwarded-For", func(tt *testing.T) {
 		e := echo.New()
 		out := capturer.CaptureStdout(func() {
-			e.Use(Middleware())
+			e.Use(Middleware(""))
 
 			e.GET("/", func(c echo.Context) error {
 				return nil
@@ -83,7 +83,7 @@ func TestMiddleware(t *testing.T) {
 	t.Run("ignores errors according to IsIgnorableError", func(tt *testing.T) {
 		e := echo.New()
 		out := capturer.CaptureStdout(func() {
-			e.Use(MiddlewareWithConfig(MiddlewareConfig{
+			e.Use(MiddlewareWithConfig("", MiddlewareConfig{
 				IsIgnorableError: func(err error) bool {
 					return true
 				},
@@ -113,7 +113,7 @@ func TestMiddleware(t *testing.T) {
 
 func TestFromEchoContext(t *testing.T) {
 	t.Run("retrieves a logger if it has been set previously", func(tt *testing.T) {
-		log := New().ID("test")
+		log := New("").ID("test")
 
 		e := echo.New()
 		req := httptest.NewRequest(echo.GET, "/", nil)

--- a/logger.go
+++ b/logger.go
@@ -54,7 +54,8 @@ func NewWithWriter(serviceName string, w io.Writer, options ...Option) Logger {
 	}
 
 	zl := zerolog.New(w).With().Timestamp()
-	zl = zl.Str("host", host).Str("release", os.Getenv("RELEASE")).Str("service", serviceName)
+	zl = zl.Str("host", host).Str("release", os.Getenv("RELEASE"))
+	zl = zl.Str("service", serviceName).Str("name", serviceName)
 
 	for _, o := range options {
 		o(&zl)
@@ -109,31 +110,41 @@ func (log Logger) Root(root Data) Logger {
 // Info outputs an info-level log with a message and any additional data
 // provided.
 func (log Logger) Info(message string, fields ...Data) {
-	log.log(log.zl.Info(), message, fields...)
+	e := log.zl.Info()
+	e.Fields(Data{"status": zerolog.LevelInfoValue})
+	log.log(e, message, fields...)
 }
 
 // Error outputs an error-level log with a message and any additional data
 // provided.
 func (log Logger) Error(message string, fields ...Data) {
-	log.log(log.zl.Error(), message, fields...)
+	e := log.zl.Error()
+	e.Fields(Data{"status": zerolog.LevelErrorValue})
+	log.log(e, message, fields...)
 }
 
 // Warn outputs a warn-level log with a message and any additional data
 // provided.
 func (log Logger) Warn(message string, fields ...Data) {
-	log.log(log.zl.Warn(), message, fields...)
+	e := log.zl.Warn()
+	e.Fields(Data{"status": zerolog.LevelWarnValue})
+	log.log(e, message, fields...)
 }
 
 // Debug outputs a debug-level log with a message and any additional data
 // provided.
 func (log Logger) Debug(message string, fields ...Data) {
-	log.log(log.zl.Debug(), message, fields...)
+	e := log.zl.Debug()
+	e.Fields(Data{"status": zerolog.LevelDebugValue})
+	log.log(e, message, fields...)
 }
 
 // Fatal outputs a fatal-level log with a message and any additional data
 // provided. This will also call os.Exit(1)
 func (log Logger) Fatal(message string, fields ...Data) {
-	log.log(log.zl.Fatal(), message, fields...)
+	e := log.zl.Fatal()
+	e.Fields(Data{"status": zerolog.LevelFatalValue})
+	log.log(e, message, fields...)
 }
 
 func (log Logger) log(evt *zerolog.Event, message string, fields ...Data) {

--- a/logger_global.go
+++ b/logger_global.go
@@ -1,7 +1,7 @@
 package logger
 
 // defaultLogger is the global logger.
-var defaultLogger = New()
+var defaultLogger = New("")
 
 // Info writes a info-level log with a message and any additional data provided.
 func Info(message string, fields ...Data) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -202,10 +201,12 @@ func TestLoggerFields(t *testing.T) {
 		expectedLog := map[string]string{
 			"host":        expectedHostname,
 			"level":       "info",
+			"status":      "info",
 			"message":     "log msg1",
 			"nanoseconds": "",
 			"release":     "mycoolrelease",
 			"service":     "asdf",
+			"name":        "asdf",
 			"id":          "myID",
 		}
 
@@ -222,6 +223,6 @@ func TestLoggerFields(t *testing.T) {
 		// then delete it from the map to test the rest a lot easier
 		delete(res, "timestamp")
 		// and finally test the map is what we expected
-		assert.True(t, reflect.DeepEqual(expectedLog, res))
+		assert.Equal(t, expectedLog, res)
 	})
 }


### PR DESCRIPTION
Add in a service field to the logger, either supplied by an env var, or on construction.  Also added options to align w/ the node logging lib (which takes a name & options): https://github.com/lob/logger-node/blob/master/lib/index.js#L112

**NOTE:** This change is an intentionally breaking one, and will force users to update their invocation when they upgrade.  This is intentional as we want users to set their dang service name, either via code or env var!